### PR TITLE
fix: already used nonce

### DIFF
--- a/examples/js/getRealCampaignExamples/PeaqDidGetRealCampaignClass.ts
+++ b/examples/js/getRealCampaignExamples/PeaqDidGetRealCampaignClass.ts
@@ -10,6 +10,10 @@ import axios from 'axios';
 import {abi} from '../MachineStationFactoryABI.json';
 import { CustomDocumentFields } from '@peaq-network/sdk/src/modules/did';
 
+// Load environment variables
+import { config } from "dotenv";
+config();
+
 // peaq RPC URL: https://peaq.api.onfinality.io/public
 const rpcURL = "https://erpc-async.agung.peaq.network"; // replace with peaq RPC URL during mainnet deployment. 
 const chainID = 3338;
@@ -23,6 +27,10 @@ const abiCoder = new AbiCoder();
 // Wallet details
 const ownerPrivateKey: string | undefined = process.env.CONTRACT_OWNER_PRIVATE_KEY??""; // Replace with owner wallet's private key
 const machineOwnerPrivateKey: string | undefined = process.env.MACHINE_OWNER_PRIVATE_KEY??""; // Replace with machine owner wallet's private key
+
+if (!ownerPrivateKey || !machineOwnerPrivateKey) {
+  throw new Error("Owner or Machine Owner Private Key not provided");
+}
 
 const provider = new ethers.JsonRpcProvider(rpcURL);
 const ownerAccount = new ethers.Wallet(ownerPrivateKey, provider);
@@ -120,7 +128,7 @@ class PeaqGetRealCampaignClass {
     async submitDIDTx() {
       try {
         const machineOwner = machineOwnerAccount.address;
-        const nonce = this.getRandomNonce();
+        let nonce = this.getRandomNonce();
         const target = "0x0000000000000000000000000000000000000800";
        
         // deploy a Machine Smart Account
@@ -169,6 +177,7 @@ class PeaqGetRealCampaignClass {
     
         const calldata = params.replace("0x", createDidFunctionSelector);
     
+        nonce = this.getRandomNonce();
         const machineOwnerSignature = await this.machineOwnerSignTypedDataExecuteMachine(machineAddress, target, calldata, nonce);
         const ownerSignature = await this.ownerSignTypedDataExecuteMachineTransaction(machineAddress, target, calldata, nonce);
     


### PR DESCRIPTION
This pull request includes several changes to the `PeaqDidGetRealCampaignClass.ts` file to improve error handling and configuration management. The most important changes include loading environment variables using the `dotenv` package, adding checks for required environment variables, and ensuring nonce values are properly assigned.

Improvements to configuration management:

* [`examples/js/getRealCampaignExamples/PeaqDidGetRealCampaignClass.ts`](diffhunk://#diff-a160b5fde050e229c833c7686bac8024b2f2941622e7bcb2582d072610cfdb47R13-R16): Added the `dotenv` package to load environment variables. (`[examples/js/getRealCampaignExamples/PeaqDidGetRealCampaignClass.tsR13-R16](diffhunk://#diff-a160b5fde050e229c833c7686bac8024b2f2941622e7bcb2582d072610cfdb47R13-R16)`)

Error handling improvements:

* [`examples/js/getRealCampaignExamples/PeaqDidGetRealCampaignClass.ts`](diffhunk://#diff-a160b5fde050e229c833c7686bac8024b2f2941622e7bcb2582d072610cfdb47R31-R34): Added checks to ensure `CONTRACT_OWNER_PRIVATE_KEY` and `MACHINE_OWNER_PRIVATE_KEY` are provided, throwing an error if they are not. (`[examples/js/getRealCampaignExamples/PeaqDidGetRealCampaignClass.tsR31-R34](diffhunk://#diff-a160b5fde050e229c833c7686bac8024b2f2941622e7bcb2582d072610cfdb47R31-R34)`)

Code consistency improvements:

* [`examples/js/getRealCampaignExamples/PeaqDidGetRealCampaignClass.ts`](diffhunk://#diff-a160b5fde050e229c833c7686bac8024b2f2941622e7bcb2582d072610cfdb47L123-R131): Changed the declaration of `nonce` to use `let` instead of `const` to allow reassignment. (`[examples/js/getRealCampaignExamples/PeaqDidGetRealCampaignClass.tsL123-R131](diffhunk://#diff-a160b5fde050e229c833c7686bac8024b2f2941622e7bcb2582d072610cfdb47L123-R131)`)
* [`examples/js/getRealCampaignExamples/PeaqDidGetRealCampaignClass.ts`](diffhunk://#diff-a160b5fde050e229c833c7686bac8024b2f2941622e7bcb2582d072610cfdb47R180): Ensured that `nonce` is reassigned with a new value before generating signatures. (`[examples/js/getRealCampaignExamples/PeaqDidGetRealCampaignClass.tsR180](diffhunk://#diff-a160b5fde050e229c833c7686bac8024b2f2941622e7bcb2582d072610cfdb47R180)`)